### PR TITLE
FLUID-6472: Update to latest Flocking. Add play button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "nexus-science-lab-synths",
-    "version": "0.0.0",
+    "version": "1.0.0",
     "description": "Synths for the Nexus Science Lab",
     "author": "OCAD University",
     "license": "BSD-3-Clause",
     "dependencies": {
-        "flocking": "0.2.0-dev.20170206T221943Z.fb09a52"
+        "flocking": "2.0.1"
     }
 }

--- a/ph.html
+++ b/ph.html
@@ -4,7 +4,13 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>pH Sonification</title>
 
+        <link rel="stylesheet" type="text/css" href="node_modules/flocking/src/ui/play-button/css/play-button.css" />
+        <link rel="stylesheet" type="text/css" href="node_modules/flocking/src/ui/shared/css/flocking-icon-font.css" />
+
         <script src="node_modules/flocking/dist/flocking-all.js"></script>
+        <script src="node_modules/flocking/src/ui/play-button/js/play-button.js"></script>
+
+        <script src="src/sonification.js"></script>
         <script src="src/ph-sonification.js"></script>
         <script src="src/buffer-loader.js"></script>
         <script src="src/ph-synth.js"></script>
@@ -13,6 +19,7 @@
 
     <body id="body">
         <main>
+            <button class="flock-playButton">Play</button>
         </main>
 
         <script type="text/javascript">

--- a/src/ph-sonification.js
+++ b/src/ph-sonification.js
@@ -1,13 +1,9 @@
 "use strict";
 
 fluid.defaults("floe.scienceLab.phSonification", {
-    gradeNames: "fluid.component",
+    gradeNames: "floe.scienceLab.sonification",
 
     components: {
-        enviro: {
-            type: "flock.enviro"
-        },
-
         synth: {
             type: "floe.scienceLab.phSynth"
         },

--- a/src/ph-synth.js
+++ b/src/ph-synth.js
@@ -3,10 +3,6 @@
 fluid.defaults("floe.scienceLab.phSynth", {
     gradeNames: "flock.synth",
 
-    components: {
-        enviro: "{phSonification}.enviro"
-    },
-
     synthDef: {
         id: "sum",
         mul: 1,

--- a/src/sonification.js
+++ b/src/sonification.js
@@ -1,0 +1,31 @@
+/**
+ * A base component for sonification demos.
+ */
+fluid.defaults("floe.scienceLab.sonification", {
+    gradeNames: "fluid.component",
+
+    distributeOptions: [
+        {
+            record: {
+                enviro: "{sonification}.enviro"
+            },
+            target: "{that flock.node}.options.components"
+        }
+    ],
+
+    components: {
+        enviro: {
+            type: "flock.enviro"
+        },
+
+        playButton: {
+            type: "flock.ui.enviroPlayButton",
+            container: ".flock-playButton",
+            options: {
+                components: {
+                    enviro: "{sonification}.enviro"
+                }
+            }
+        }
+    }
+});

--- a/src/temperature-sonification.js
+++ b/src/temperature-sonification.js
@@ -1,19 +1,11 @@
 "use strict";
 
 fluid.defaults("floe.scienceLab.temperatureSonification", {
-    gradeNames: "fluid.component",
+    gradeNames: "floe.scienceLab.sonification",
 
     components: {
-        enviro: {
-            type: "flock.enviro"
-        },
-
         band: {
             type: "floe.scienceLab.temperatureBand"
         }
-    },
-
-    listeners: {
-        "onCreate.startSynths": "{band}.play()"
     }
 });

--- a/temperature.html
+++ b/temperature.html
@@ -3,8 +3,13 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>Temperature Sonification</title>
+        <link rel="stylesheet" type="text/css" href="node_modules/flocking/src/ui/play-button/css/play-button.css" />
+        <link rel="stylesheet" type="text/css" href="node_modules/flocking/src/ui/shared/css/flocking-icon-font.css" />
 
         <script src="node_modules/flocking/dist/flocking-all.js"></script>
+        <script src="node_modules/flocking/src/ui/play-button/js/play-button.js"></script>
+
+        <script src="src/sonification.js"></script>
         <script src="src/temperature-sonification.js"></script>
         <script src="src/temperature-synth.js"></script>
 
@@ -12,6 +17,7 @@
 
     <body id="body">
         <main>
+            <button class="flock-playButton">Play</button>
         </main>
 
         <script type="text/javascript">


### PR DESCRIPTION
This PR, which I pair programmed with @ptcher, updates the science lab synths to use the latest version of Flocking, and tidies up the code and handling of Flocking Environments. It also introduces Play/Pause buttons in order to address the constraints most modern browsers now place on audio playback—which should always be the result of a user action.